### PR TITLE
Makefile fixes.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,9 +17,9 @@ FILES = COPYING NEWS ChangeLog Makefile \
  checkdist \
  .gitignore selftest
 
-prefix = /usr
-bindir = $(prefix)/bin
-mandir = $(prefix)/man
+PREFIX ?= /usr/local
+bindir = /bin
+mandir = /man
 
 genromfs: genromfs.o
 	$(CC) $(LDFLAGS) genromfs.o -o genromfs
@@ -55,9 +55,6 @@ install-bin:
 install-man:
 	# genromfs 0.5 installed the man page in this file,
 	# remove it before someone notices :)
-	if [ -f $(PREFIX)$(bindir)/man8 ]; then \
-		rm -f $(PREFIX)$(bindir)/man8; \
-	fi
 	mkdir -p $(PREFIX)$(mandir)/man8
 	install -m 644 genromfs.8 $(PREFIX)$(mandir)/man8/
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ all: genromfs
 
 PACKAGE = genromfs
 VERSION = 0.5.7
-CC = gcc
+CC = cc
 CFLAGS = -O2 -Wall -DVERSION=\"$(VERSION)\"#-g#
 LDFLAGS = -s#-g
 


### PR DESCRIPTION
It is safe to use cc instead of gcc on BSD and Linux.
FreeBSD switched gcc to clang/llvm around 2012, no gcc in base anymore.

You can now `make PREFIX=/usr/local install` to perform valid installation.
If variable is not provided it is set to `/usr/local` outside base OS.

During install Makefile silently removed whole man8 directory!!! Fixed.

Signed-off-by: Tomasz 'CeDeROM' CEDRO <tomek@cedro.info>