### PR TITLE
* genromfs.c (alignnode): close(fd) after read

### DIFF
--- a/genromfs.c
+++ b/genromfs.c
@@ -632,6 +632,7 @@ int alignnode(struct filenode *node, int curroffset, int extraspace)
 			if ((fd = open(node->realname, O_RDBIN)) >= 0) {
 				memset(bigbuf, 0, 16);
 				read(fd, bigbuf, 16);
+				close(fd);
 				checkpos = 0;
 			}
 		} else if (S_ISLNK(node->modes)) {


### PR DESCRIPTION
Issue:
In MSYS2, when processing a large set of files (approximately 9,000), genromfs displays the error:

"Too many open files"

Fix:
To resolve this, the open file handles are now explicitly closed after reading, preventing the system from exceeding the file descriptor limit.